### PR TITLE
GitHub Actions and Gradle for Publishing Snapshot and Release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run Lint
+        run: |
+          ./gradlew clean ktlintCheck

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Update snapshot version
         run: |
-          ./gradlew updateVersion -Pversion=${{ github.event.release.tag_name }} --rerun-tasks
+          ./gradlew updateVersion -PreleaseVersion=${{ github.event.release.tag_name }} --rerun-tasks
 
       - name: Commit gradle.properties
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  deploy:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Get AWS CodeArtifact auth token
+        run: |
+          echo "auth_token=$(aws codeartifact get-authorization-token \
+            --domain wafflestudio --domain-owner 405906814034 \
+            --query authorizationToken --region ap-northeast-1)" \
+            >> $GITHUB_ENV
+
+      - name: Publish release
+        run: |
+          ./gradlew clean publish -PauthToken=${{ env.auth_token }} -Pversion=${{ github.event.release.tag_name }}
+
+      - name: Update snapshot version
+        run: |
+          ./gradlew updateVersion -Pversion=${{ github.event.release.tag_name }}
+
+      - name: Commit gradle.properties
+        run: |
+          git config --global user.name 'truffle-kotlin'
+          git config --global user.email 'truffle-kotlin@wafflestudio.com'
+          git add ./gradle.properties
+          git commit -m "Automated commit by GitHub Actions"
+          git push

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Update snapshot version
         run: |
-          ./gradlew updateVersion -Pversion=${{ github.event.release.tag_name }}
+          ./gradlew updateVersion -Pversion=${{ github.event.release.tag_name }} --rerun-tasks
 
       - name: Commit gradle.properties
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,16 +19,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Get AWS CodeArtifact auth token
-        run: |
-          echo "auth_token=$(aws codeartifact get-authorization-token \
-            --domain wafflestudio --domain-owner 405906814034 \
-            --query authorizationToken --region ap-northeast-1)" \
-            >> $GITHUB_ENV
-
       - name: Publish release
         run: |
-          ./gradlew clean publish -PauthToken=${{ env.auth_token }} -Pversion=${{ github.event.release.tag_name }}
+          ./gradlew clean publish -Pversion=${{ github.event.release.tag_name }}
 
       - name: Update snapshot version
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,13 +19,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Get AWS CodeArtifact auth token
-        run: |
-          echo "auth_token=$(aws codeartifact get-authorization-token \
-            --domain wafflestudio --domain-owner 405906814034 \
-            --query authorizationToken --region ap-northeast-1)" \
-            >> $GITHUB_ENV
-
       - name: Publish snapshot
         run: |
-          ./gradlew clean publish -PauthToken=${{ env.auth_token }}
+          ./gradlew clean publish

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Get AWS CodeArtifact auth token
+        run: |
+          echo "auth_token=$(aws codeartifact get-authorization-token \
+            --domain wafflestudio --domain-owner 405906814034 \
+            --query authorizationToken --region ap-northeast-1)" \
+            >> $GITHUB_ENV
+
+      - name: Publish snapshot
+        run: |
+          ./gradlew clean publish -PauthToken=${{ env.auth_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run Lint
+        run: |
+          ./gradlew clean test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.Properties
@@ -50,6 +51,20 @@ allprojects {
     }
 
     publishing {
+        val authToken = ByteArrayOutputStream().use {
+            runCatching {
+                exec {
+                    commandLine = (
+                        "aws codeartifact get-authorization-token " +
+                            "--domain wafflestudio --domain-owner 405906814034 " +
+                            "--query authorizationToken --region ap-northeast-1 --output text"
+                        ).split(" ")
+                    standardOutput = it
+                }
+            }
+            it.toString()
+        }
+
         repositories {
             maven {
                 version = properties["version"]!!
@@ -57,7 +72,7 @@ allprojects {
                 url = uri("https://wafflestudio-405906814034.d.codeartifact.ap-northeast-1.amazonaws.com/maven/truffle-kotlin/")
                 credentials {
                     username = "aws"
-                    password = properties["authToken"].toString()
+                    password = authToken
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.Properties
 
 plugins {
     id("org.springframework.boot") version "3.0.1" apply false
@@ -6,6 +9,7 @@ plugins {
     kotlin("jvm") version "1.8.0"
     kotlin("plugin.spring") version "1.8.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    id("maven-publish")
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_17
@@ -45,6 +49,28 @@ allprojects {
         testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     }
 
+    publishing {
+        repositories {
+            maven {
+                version = properties["version"]!!
+                name = "wafflestudio"
+                url = uri("https://wafflestudio-405906814034.d.codeartifact.ap-northeast-1.amazonaws.com/maven/truffle-kotlin/")
+                credentials {
+                    username = "aws"
+                    password = properties["authToken"].toString()
+                }
+            }
+        }
+
+        println(properties["authToken"].toString())
+
+        publications {
+            register<MavenPublication>("truffle-kotlin") {
+                from(components["java"])
+            }
+        }
+    }
+
     tasks.withType<KotlinCompile> {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict")
@@ -54,5 +80,20 @@ allprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
+    }
+}
+
+task("updateVersion") {
+    properties["releaseVersion"]?.let { releaseVersion ->
+        val newSnapshotVersion = (releaseVersion as String).split(".").let {
+            "${it[0]}.${it[1].toInt() + 1}.0-SNAPSHOT"
+        }
+
+        val file = File(rootDir, "gradle.properties")
+        val prop = Properties().apply { load(FileInputStream(file)) }
+        if (prop.getProperty("version") != newSnapshotVersion) {
+            prop.setProperty("version", newSnapshotVersion)
+            prop.store(FileOutputStream(file), null)
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,6 @@ allprojects {
             }
         }
 
-        println(properties["authToken"].toString())
-
         publications {
             register<MavenPublication>("truffle-kotlin") {
                 from(components["java"])

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
-group=com.wafflestudio.truffle.sdk
-version=1.0.0-SNAPSHOT
+#Thu Jan 26 02:26:27 KST 2023
 kotlin.code.style=official
+version=1.0.0-SNAPSHOT
+group=com.wafflestudio.truffle.sdk


### PR DESCRIPTION
아직 aws 권한을 덜 받았고 로컬 테스트에 한계가 있어서… merge 후에도 GitHub Actions 돌려보면서 삽질 좀 할 수도 있습니다.

master merge 시 자동으로 gradle.properties 써져있는 X.X.X-SNAPSHOT 버전으로 계속 덮어쓰면서 CodeArtifact 에 publish 하고,
수동 tag release 시 해당 버전 tag (X.X.X)의 release 를 CodeArtifact 에 publish 하는 방식으로 생각했습니다.

updateVersion 이라는 task 는 예를 들어,
`1.0.1` 을 releaseVersion 으로 publish 하고 나면, 자동으로 gradle.properties 의 version 을 `1.1.0-SNAPSHOT`으로 바꿔주어,
이후 신경 쓸 필요 없이 계속 master 에 merge 해서 새로운 snapshot 을 배포할 수 있게 하는 것입니다.

이런 방식이 별로거나 더 좋은 의견 있다면 말씀주세요.