### PR TITLE
Use AutoConfiguration.imports & Don't send report for local and test phases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.io.FileOutputStream
 import java.util.Properties
 
 plugins {
-    id("org.springframework.boot") version "3.0.1" apply false
+    id("org.springframework.boot") version "3.0.3" apply false
     id("io.spring.dependency-management") version "1.1.0"
     kotlin("jvm") version "1.8.0"
     kotlin("plugin.spring") version "1.8.0"

--- a/truffle-core/src/main/kotlin/TruffleClient.kt
+++ b/truffle-core/src/main/kotlin/TruffleClient.kt
@@ -59,6 +59,8 @@ class DefaultTruffleClient(
     }
 
     override fun sendEvent(ex: Throwable) {
+        if (truffleApp.phase == "local" || truffleApp.phase == "test") return
+
         events.tryEmit(
             TruffleEvent(
                 app = truffleApp,

--- a/truffle-core/src/main/kotlin/protocol/TruffleApp.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleApp.kt
@@ -2,5 +2,5 @@ package com.wafflestudio.truffle.sdk.core.protocol
 
 data class TruffleApp(
     val name: String,
-    val phase: String? = null,
+    val phase: String,
 )

--- a/truffle-spring-boot-starter/src/main/kotlin/TruffleProperties.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/TruffleProperties.kt
@@ -4,7 +4,23 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("truffle.client")
 data class TruffleProperties(
+    /**
+     * Truffle 이 식별하는 애플리케이션의 이름.
+     *
+     * 에러 리포트에 사용되며 Truffle 서버에 등록된 이름과 일치하는 정확한 애플리케이션 이름이 사용되어야 합니다.
+     */
     val name: String,
+    /**
+     * 애플리케이션의 환경을 구분하는 이름.
+     *
+     * 에러 리포트에 사용되며 `"prod"`, `"dev"`, `"local"` 등이 사용될 수 있습니다.
+     * `"local"` 또는 `"test"`가 사용되는 경우, Truffle SDK 는 Truffle 서버로 요청을 전송하지 않습니다.
+     */
     val phase: String,
+    /**
+     * Truffle 서버에서 애플리케이션의 요청이 유효한지 검증하는 데에 사용하는 API key.
+     *
+     * 외부에 공개되지 않도록 주의해 관리해야 합니다.
+     */
     val apiKey: String,
 )

--- a/truffle-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/truffle-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.wafflestudio.truffle.sdk.TruffleAutoConfiguration


### PR DESCRIPTION
1. Spring Boot 3 을 고려해 `org.springframework.boot.autoconfigure.AutoConfiguration.imports` 추가
2. local, test 와 같은 phase 에서는 서버로 전송하지 않도록 함. 관련 javadoc 추가.
3. 불필요한 nullable 제거.

* * *

별개로, snu4t 에 적용하면서 본 건데, 지금 snu4t 가 쓰고 있는 [WebFilter](https://github.com/wafflestudio/snutt-timetable/blob/develop/api/src/main/kotlin/filter/ErrorWebFilter.kt) 의 에러 핸들링 방식이, 모든 에러를 잡아버리는 것이라 `WebExceptionHandler` 가 적용될 기회 자체가 없더라구요. 어떤 방식으로 문제를 해결하면 좋을까요? @PFCJeong 

WebFilter 의 의의는 기존 snutt(core) 처럼, 어떤 에러의 경우에도 클라와 합의된 인터페이스로 response body 를 전달하기 위한 것이었습니다.