### PR TITLE
logback integration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 rootProject.name = "truffle-kotlin"
 
 include("truffle-core")
+include("truffle-logback")
 include("truffle-spring-boot-starter")

--- a/truffle-core/src/main/kotlin/Hub.kt
+++ b/truffle-core/src/main/kotlin/Hub.kt
@@ -8,7 +8,6 @@ internal class Hub(
     webClientBuilder: WebClient.Builder? = null,
 ) : IHub {
     private val client: TruffleClient = DefaultTruffleClient(
-        phase = truffleOptions.phase,
         apiKey = truffleOptions.apiKey,
         webClientBuilder = webClientBuilder ?: WebClient.builder(),
     )

--- a/truffle-core/src/main/kotlin/Hub.kt
+++ b/truffle-core/src/main/kotlin/Hub.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.truffle.sdk.core
+
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+import org.springframework.web.reactive.function.client.WebClient
+
+class Hub(
+    truffleOptions: TruffleOptions,
+    webClientBuilder: WebClient.Builder? = null,
+) : IHub {
+    private val client: TruffleClient = DefaultTruffleClient(
+        phase = truffleOptions.phase,
+        apiKey = truffleOptions.apiKey,
+        webClientBuilder = webClientBuilder ?: WebClient.builder(),
+    )
+
+    override fun captureEvent(truffleEvent: TruffleEvent) {
+        client.sendEvent(truffleEvent)
+    }
+}

--- a/truffle-core/src/main/kotlin/Hub.kt
+++ b/truffle-core/src/main/kotlin/Hub.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.truffle.sdk.core
 import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
 import org.springframework.web.reactive.function.client.WebClient
 
-class Hub(
+internal class Hub(
     truffleOptions: TruffleOptions,
     webClientBuilder: WebClient.Builder? = null,
 ) : IHub {

--- a/truffle-core/src/main/kotlin/IHub.kt
+++ b/truffle-core/src/main/kotlin/IHub.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.truffle.sdk.core
+
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+
+interface IHub {
+    fun captureEvent(truffleEvent: TruffleEvent)
+}

--- a/truffle-core/src/main/kotlin/Truffle.kt
+++ b/truffle-core/src/main/kotlin/Truffle.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.truffle.sdk.core
+
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+import org.slf4j.LoggerFactory
+import org.springframework.web.reactive.function.client.WebClient
+
+object Truffle {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private lateinit var hub: IHub
+
+    @Synchronized fun isInitialized(): Boolean {
+        return ::hub.isInitialized
+    }
+
+    // for modules without access WebClient.Builder
+    fun init(truffleOptions: TruffleOptions): IHub {
+        return init(truffleOptions, null)
+    }
+
+    @Synchronized fun init(truffleOptions: TruffleOptions, webClientBuilder: WebClient.Builder? = null): IHub {
+        if (isInitialized()) {
+            logger.warn("Truffle is already initialized. Previous configuration will be used.")
+            return hub
+        }
+
+        validateConfig(truffleOptions)
+
+        val hub = Hub(truffleOptions, webClientBuilder)
+        this.hub = hub
+        return hub
+    }
+
+    fun captureEvent(truffleEvent: TruffleEvent) {
+        hub.captureEvent(truffleEvent)
+    }
+
+    private fun validateConfig(truffleOptions: TruffleOptions) {
+        if (truffleOptions.apiKey.isBlank()) {
+            throw IllegalArgumentException("Truffle API key is blank")
+        }
+        if (truffleOptions.phase.isBlank()) {
+            throw IllegalArgumentException("Truffle phase is blank")
+        }
+    }
+}

--- a/truffle-core/src/main/kotlin/Truffle.kt
+++ b/truffle-core/src/main/kotlin/Truffle.kt
@@ -36,8 +36,5 @@ object Truffle {
         if (truffleOptions.apiKey.isBlank()) {
             throw IllegalArgumentException("Truffle API key is blank")
         }
-        if (truffleOptions.phase.isBlank()) {
-            throw IllegalArgumentException("Truffle phase is blank")
-        }
     }
 }

--- a/truffle-core/src/main/kotlin/TruffleClient.kt
+++ b/truffle-core/src/main/kotlin/TruffleClient.kt
@@ -18,7 +18,6 @@ internal interface TruffleClient {
 }
 
 internal class DefaultTruffleClient(
-    private val phase: String,
     apiKey: String,
     webClientBuilder: WebClient.Builder,
 ) : TruffleClient {
@@ -53,8 +52,6 @@ internal class DefaultTruffleClient(
     }
 
     override fun sendEvent(truffleEvent: TruffleEvent) {
-        if (phase == "local" || phase == "test") return
-
         events.tryEmit(truffleEvent)
     }
 }

--- a/truffle-core/src/main/kotlin/TruffleClient.kt
+++ b/truffle-core/src/main/kotlin/TruffleClient.kt
@@ -1,9 +1,6 @@
 package com.wafflestudio.truffle.sdk.core
 
-import com.wafflestudio.truffle.sdk.core.protocol.TruffleApp
 import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
-import com.wafflestudio.truffle.sdk.core.protocol.TruffleException
-import com.wafflestudio.truffle.sdk.core.protocol.TruffleRuntime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -17,24 +14,21 @@ import java.time.Duration
 import java.util.concurrent.Executors
 
 interface TruffleClient {
-    fun sendEvent(ex: Throwable)
+    fun sendEvent(truffleEvent: TruffleEvent)
 }
 
 class DefaultTruffleClient(
-    name: String,
-    phase: String,
+    private val phase: String,
     apiKey: String,
     webClientBuilder: WebClient.Builder,
 ) : TruffleClient {
     private val events = MutableSharedFlow<TruffleEvent>(extraBufferCapacity = 10)
-
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    private val truffleApp = TruffleApp(name, phase)
-    private val truffleRuntime = TruffleRuntime(name = "Java", version = System.getProperty("java.version"))
-
     init {
-        val coroutineScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+        val coroutineScope = CoroutineScope(
+            Executors.newSingleThreadExecutor { r -> Thread(r, "truffle-client") }.asCoroutineDispatcher()
+        )
         val webClient = webClientBuilder
             .baseUrl("https://truffle-api.wafflestudio.com")
             .defaultHeader("x-api-key", apiKey)
@@ -58,15 +52,8 @@ class DefaultTruffleClient(
         }
     }
 
-    override fun sendEvent(ex: Throwable) {
-        if (truffleApp.phase == "local" || truffleApp.phase == "test") return
-
-        events.tryEmit(
-            TruffleEvent(
-                app = truffleApp,
-                runtime = truffleRuntime,
-                exception = TruffleException(ex),
-            )
-        )
+    override fun sendEvent(truffleEvent: TruffleEvent) {
+        if (phase == "local" || phase == "test") return
+        events.tryEmit(truffleEvent)
     }
 }

--- a/truffle-core/src/main/kotlin/TruffleClient.kt
+++ b/truffle-core/src/main/kotlin/TruffleClient.kt
@@ -13,11 +13,11 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import java.time.Duration
 import java.util.concurrent.Executors
 
-interface TruffleClient {
+internal interface TruffleClient {
     fun sendEvent(truffleEvent: TruffleEvent)
 }
 
-class DefaultTruffleClient(
+internal class DefaultTruffleClient(
     private val phase: String,
     apiKey: String,
     webClientBuilder: WebClient.Builder,
@@ -54,6 +54,7 @@ class DefaultTruffleClient(
 
     override fun sendEvent(truffleEvent: TruffleEvent) {
         if (phase == "local" || phase == "test") return
+
         events.tryEmit(truffleEvent)
     }
 }

--- a/truffle-core/src/main/kotlin/TruffleOptions.kt
+++ b/truffle-core/src/main/kotlin/TruffleOptions.kt
@@ -1,17 +1,14 @@
-package com.wafflestudio.truffle.sdk
+package com.wafflestudio.truffle.sdk.core
 
 import ch.qos.logback.classic.Level
-import com.wafflestudio.truffle.sdk.core.TruffleOptions
-import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties("truffle.client")
-data class TruffleProperties(
+open class TruffleOptions {
     /**
      * Truffle 서버에서 애플리케이션의 요청이 유효한지 검증하는 데에 사용하는 API key.
      *
      * 외부에 공개되지 않도록 주의해 관리해야 합니다.
      */
-    override var apiKey: String,
+    open lateinit var apiKey: String
 
     /**
      * 애플리케이션의 환경을 구분하는 이름.
@@ -19,10 +16,10 @@ data class TruffleProperties(
      * 에러 리포트에 사용되며 `"prod"`, `"dev"`, `"local"` 등이 사용될 수 있습니다.
      * `"local"` 또는 `"test"`가 사용되는 경우, Truffle SDK 는 Truffle 서버로 요청을 전송하지 않습니다.
      */
-    override var phase: String,
+    open lateinit var phase: String
 
     /**
      * truffle logback 사용 시 이벤트를 전송할 최소 로그 레벨.
      */
-    override var minimumLevel: Level = Level.ERROR,
-) : TruffleOptions()
+    open var minimumLevel: Level = Level.ERROR
+}

--- a/truffle-core/src/main/kotlin/TruffleOptions.kt
+++ b/truffle-core/src/main/kotlin/TruffleOptions.kt
@@ -11,14 +11,6 @@ open class TruffleOptions {
     open lateinit var apiKey: String
 
     /**
-     * 애플리케이션의 환경을 구분하는 이름.
-     *
-     * 에러 리포트에 사용되며 `"prod"`, `"dev"`, `"local"` 등이 사용될 수 있습니다.
-     * `"local"` 또는 `"test"`가 사용되는 경우, Truffle SDK 는 Truffle 서버로 요청을 전송하지 않습니다.
-     */
-    open lateinit var phase: String
-
-    /**
      * truffle logback 사용 시 이벤트를 전송할 최소 로그 레벨.
      */
     open var minimumLevel: Level = Level.ERROR

--- a/truffle-core/src/main/kotlin/protocol/TruffleApp.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleApp.kt
@@ -1,6 +1,0 @@
-package com.wafflestudio.truffle.sdk.core.protocol
-
-data class TruffleApp(
-    val name: String,
-    val phase: String,
-)

--- a/truffle-core/src/main/kotlin/protocol/TruffleAppInfo.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleAppInfo.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.truffle.sdk.core.protocol
+
+object TruffleAppInfo {
+    val runtime = TruffleRuntime()
+
+    data class TruffleRuntime(
+        val name: String = "Java",
+        val version: String = System.getProperty("java.version")
+    )
+}

--- a/truffle-core/src/main/kotlin/protocol/TruffleEvent.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleEvent.kt
@@ -2,8 +2,7 @@ package com.wafflestudio.truffle.sdk.core.protocol
 
 data class TruffleEvent(
     val version: String = TruffleVersion.V1,
-    val runtime: TruffleRuntime = TruffleRuntime,
+    val runtime: TruffleAppInfo.TruffleRuntime = TruffleAppInfo.runtime,
     val level: TruffleLevel,
-    val exception: TruffleException?,
-    val message: String?,
+    val exception: TruffleException,
 )

--- a/truffle-core/src/main/kotlin/protocol/TruffleEvent.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleEvent.kt
@@ -2,7 +2,8 @@ package com.wafflestudio.truffle.sdk.core.protocol
 
 data class TruffleEvent(
     val version: String = TruffleVersion.V1,
-    val app: TruffleApp,
-    val runtime: TruffleRuntime,
-    val exception: TruffleException,
+    val runtime: TruffleRuntime = TruffleRuntime,
+    val level: TruffleLevel,
+    val exception: TruffleException?,
+    val message: String?,
 )

--- a/truffle-core/src/main/kotlin/protocol/TruffleLevel.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleLevel.kt
@@ -1,0 +1,23 @@
+package com.wafflestudio.truffle.sdk.core.protocol
+
+import ch.qos.logback.classic.Level
+
+enum class TruffleLevel {
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL,
+    ;
+
+    companion object {
+        fun from(level: Level): TruffleLevel {
+            return when {
+                level.isGreaterOrEqual(Level.ERROR) -> ERROR
+                level.isGreaterOrEqual(Level.WARN) -> WARNING
+                level.isGreaterOrEqual(Level.INFO) -> INFO
+                else -> DEBUG
+            }
+        }
+    }
+}

--- a/truffle-core/src/main/kotlin/protocol/TruffleRuntime.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleRuntime.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.truffle.sdk.core.protocol
 
-data class TruffleRuntime(
-    val name: String,
-    val version: String,
-)
+object TruffleRuntime {
+    const val name = "Java"
+    val version = System.getProperty("java.version")
+}

--- a/truffle-core/src/main/kotlin/protocol/TruffleRuntime.kt
+++ b/truffle-core/src/main/kotlin/protocol/TruffleRuntime.kt
@@ -1,6 +1,0 @@
-package com.wafflestudio.truffle.sdk.core.protocol
-
-object TruffleRuntime {
-    const val name = "Java"
-    val version = System.getProperty("java.version")
-}

--- a/truffle-logback/build.gradle.kts
+++ b/truffle-logback/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    compileOnly("ch.qos.logback:logback-classic")
+
+    implementation(project(":truffle-core"))
+}

--- a/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
+++ b/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.truffle.sdk.logback
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.ThrowableProxy
+import ch.qos.logback.core.UnsynchronizedAppenderBase
+import com.wafflestudio.truffle.sdk.core.Truffle
+import com.wafflestudio.truffle.sdk.core.TruffleOptions
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleException
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleLevel
+
+class TruffleAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
+    lateinit var options: TruffleOptions
+
+    override fun start() {
+        if (!Truffle.isInitialized()) {
+            Truffle.init(options)
+        }
+        super.start()
+    }
+
+    override fun append(eventObject: ILoggingEvent) {
+        if (eventObject.level.isGreaterOrEqual(options.minimumLevel) &&
+            !eventObject.loggerName.startsWith("com.wafflestudio.truffle.sdk")
+        ) {
+            val truffleEvent = createEvent(eventObject)
+            Truffle.captureEvent(truffleEvent)
+        }
+    }
+
+    private fun createEvent(eventObject: ILoggingEvent): TruffleEvent {
+        val exception = eventObject.throwableProxy?.let {
+            TruffleException((it as ThrowableProxy).throwable)
+        }
+
+        return TruffleEvent(
+            level = TruffleLevel.from(eventObject.level),
+            message = eventObject.formattedMessage,
+            exception = exception,
+        )
+    }
+}

--- a/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
+++ b/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
@@ -31,11 +31,22 @@ class TruffleAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
     private fun createEvent(eventObject: ILoggingEvent): TruffleEvent {
         val exception = eventObject.throwableProxy?.let {
             TruffleException((it as ThrowableProxy).throwable)
-        }
+        } ?: TruffleException(
+            className = eventObject.loggerName,
+            message = eventObject.formattedMessage,
+            elements = eventObject.callerData.map {
+                TruffleException.Element(
+                    className = it.className,
+                    methodName = it.methodName,
+                    fileName = it.fileName ?: "",
+                    lineNumber = it.lineNumber,
+                    isInAppInclude = true, // FIXME
+                )
+            },
+        )
 
         return TruffleEvent(
             level = TruffleLevel.from(eventObject.level),
-            message = eventObject.formattedMessage,
             exception = exception,
         )
     }

--- a/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
+++ b/truffle-logback/src/main/kotlin/appender/TruffleAppender.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.truffle.sdk.logback
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.spi.ThrowableProxy
 import ch.qos.logback.core.UnsynchronizedAppenderBase
+import com.wafflestudio.truffle.sdk.core.IHub
 import com.wafflestudio.truffle.sdk.core.Truffle
 import com.wafflestudio.truffle.sdk.core.TruffleOptions
 import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
@@ -11,11 +12,10 @@ import com.wafflestudio.truffle.sdk.core.protocol.TruffleLevel
 
 class TruffleAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
     lateinit var options: TruffleOptions
+    private lateinit var hub: IHub
 
     override fun start() {
-        if (!Truffle.isInitialized()) {
-            Truffle.init(options)
-        }
+        hub = Truffle.init(options)
         super.start()
     }
 
@@ -24,7 +24,7 @@ class TruffleAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
             !eventObject.loggerName.startsWith("com.wafflestudio.truffle.sdk")
         ) {
             val truffleEvent = createEvent(eventObject)
-            Truffle.captureEvent(truffleEvent)
+            hub.captureEvent(truffleEvent)
         }
     }
 

--- a/truffle-spring-boot-starter/build.gradle.kts
+++ b/truffle-spring-boot-starter/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     implementation(project(":truffle-core"))
+    compileOnly(project(":truffle-logback"))
 }

--- a/truffle-spring-boot-starter/src/main/kotlin/TruffleAutoConfiguration.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/TruffleAutoConfiguration.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.truffle.sdk
 import ch.qos.logback.classic.LoggerContext
 import com.wafflestudio.truffle.sdk.core.IHub
 import com.wafflestudio.truffle.sdk.core.Truffle
+import com.wafflestudio.truffle.sdk.logback.TruffleAppender
 import com.wafflestudio.truffle.sdk.reactive.TruffleWebExceptionHandler
 import com.wafflestudio.truffle.sdk.servlet.TruffleHandlerExceptionResolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -41,7 +42,7 @@ class TruffleAutoConfiguration {
         }
     }
 
-    @ConditionalOnClass(LoggerContext::class)
+    @ConditionalOnClass(value = [LoggerContext::class, TruffleAppender::class])
     @ConditionalOnProperty(value = ["truffle.logback.enabled"], havingValue = "true", matchIfMissing = true)
     @Configuration
     class TruffleLogbackConfiguration {

--- a/truffle-spring-boot-starter/src/main/kotlin/TruffleAutoConfiguration.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/TruffleAutoConfiguration.kt
@@ -17,6 +17,7 @@ import org.springframework.web.server.WebExceptionHandler
 import org.springframework.web.servlet.HandlerExceptionResolver
 
 @EnableConfigurationProperties(TruffleProperties::class)
+@ConditionalOnProperty(value = ["truffle.enabled"], havingValue = "true")
 @Configuration
 class TruffleAutoConfiguration {
     @Bean

--- a/truffle-spring-boot-starter/src/main/kotlin/TruffleLogbackInitializer.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/TruffleLogbackInitializer.kt
@@ -1,0 +1,43 @@
+package com.wafflestudio.truffle.sdk
+
+import ch.qos.logback.classic.LoggerContext
+import com.wafflestudio.truffle.sdk.logback.TruffleAppender
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.context.event.GenericApplicationListener
+import org.springframework.core.ResolvableType
+import ch.qos.logback.classic.Logger as LogbackLogger
+
+class TruffleLogbackInitializer(
+    private val truffleProperties: TruffleProperties,
+) : GenericApplicationListener {
+    override fun supportsEventType(eventType: ResolvableType): Boolean {
+        return eventType.rawClass?.let { ContextRefreshedEvent::class.java.isAssignableFrom(it) } ?: false
+    }
+
+    override fun onApplicationEvent(event: ApplicationEvent) {
+        val rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as LogbackLogger
+
+        if (!isTruffleAppenderRegistered(rootLogger)) {
+            val truffleAppender = TruffleAppender()
+            truffleAppender.name = "TRUFFLE_APPENDER"
+            truffleAppender.context = LoggerFactory.getILoggerFactory() as LoggerContext
+            truffleAppender.options = truffleProperties
+
+            truffleAppender.start()
+            rootLogger.addAppender(truffleAppender)
+        }
+    }
+
+    private fun isTruffleAppenderRegistered(logger: LogbackLogger): Boolean {
+        val iterator = logger.iteratorForAppenders()
+        while (iterator.hasNext()) {
+            if (iterator.next() is TruffleAppender) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/truffle-spring-boot-starter/src/main/kotlin/TruffleProperties.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/TruffleProperties.kt
@@ -14,14 +14,6 @@ data class TruffleProperties(
     override var apiKey: String,
 
     /**
-     * 애플리케이션의 환경을 구분하는 이름.
-     *
-     * 에러 리포트에 사용되며 `"prod"`, `"dev"`, `"local"` 등이 사용될 수 있습니다.
-     * `"local"` 또는 `"test"`가 사용되는 경우, Truffle SDK 는 Truffle 서버로 요청을 전송하지 않습니다.
-     */
-    override var phase: String,
-
-    /**
      * truffle logback 사용 시 이벤트를 전송할 최소 로그 레벨.
      */
     override var minimumLevel: Level = Level.ERROR,

--- a/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
@@ -18,7 +18,6 @@ class TruffleWebExceptionHandler(private val hub: IHub) : WebExceptionHandler {
                 TruffleEvent(
                     level = TruffleLevel.FATAL,
                     exception = TruffleException(ex),
-                    message = null,
                 )
             )
         }

--- a/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
@@ -1,6 +1,9 @@
 package com.wafflestudio.truffle.sdk.reactive
 
-import com.wafflestudio.truffle.sdk.core.TruffleClient
+import com.wafflestudio.truffle.sdk.core.IHub
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleException
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleLevel
 import org.springframework.core.annotation.Order
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
@@ -8,12 +11,16 @@ import org.springframework.web.server.WebExceptionHandler
 import reactor.core.publisher.Mono
 
 @Order(-2)
-class TruffleWebExceptionHandler(
-    private val truffleClient: TruffleClient,
-) : WebExceptionHandler {
+class TruffleWebExceptionHandler(private val hub: IHub) : WebExceptionHandler {
     override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> {
         if (ex !is ResponseStatusException) {
-            truffleClient.sendEvent(ex)
+            hub.captureEvent(
+                TruffleEvent(
+                    level = TruffleLevel.FATAL,
+                    exception = TruffleException(ex),
+                    message = null,
+                )
+            )
         }
 
         return Mono.error(ex)

--- a/truffle-spring-boot-starter/src/main/kotlin/servlet/TruffleHandlerExceptionResolver.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/servlet/TruffleHandlerExceptionResolver.kt
@@ -24,7 +24,6 @@ class TruffleHandlerExceptionResolver(private val hub: IHub) : HandlerExceptionR
                 TruffleEvent(
                     level = TruffleLevel.FATAL,
                     exception = TruffleException(ex),
-                    message = null,
                 )
             )
         }

--- a/truffle-spring-boot-starter/src/main/kotlin/servlet/TruffleHandlerExceptionResolver.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/servlet/TruffleHandlerExceptionResolver.kt
@@ -1,18 +1,18 @@
 package com.wafflestudio.truffle.sdk.servlet
 
-import com.wafflestudio.truffle.sdk.core.TruffleClient
+import com.wafflestudio.truffle.sdk.core.IHub
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleEvent
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleException
+import com.wafflestudio.truffle.sdk.core.protocol.TruffleLevel
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.core.annotation.Order
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.HandlerExceptionResolver
 import org.springframework.web.servlet.ModelAndView
-import java.lang.Exception
 
 @Order(-2)
-class TruffleHandlerExceptionResolver(
-    private val truffleClient: TruffleClient,
-) : HandlerExceptionResolver {
+class TruffleHandlerExceptionResolver(private val hub: IHub) : HandlerExceptionResolver {
     override fun resolveException(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -20,7 +20,13 @@ class TruffleHandlerExceptionResolver(
         ex: Exception,
     ): ModelAndView? {
         if (ex !is ResponseStatusException) {
-            truffleClient.sendEvent(ex)
+            hub.captureEvent(
+                TruffleEvent(
+                    level = TruffleLevel.FATAL,
+                    exception = TruffleException(ex),
+                    message = null,
+                )
+            )
         }
 
         return null

--- a/truffle-spring-boot-starter/src/test/resources/application.yml
+++ b/truffle-spring-boot-starter/src/test/resources/application.yml
@@ -1,5 +1,4 @@
 truffle:
+  enabled: true
   client:
-    name: snutt
-    phase: dev
     api-key: abcdef


### PR DESCRIPTION
당연히 sentry logback 을 참고했습니다.

- - -

**의도한 부분은 아래와 같습니다.**

1. truffle-spring-boot-starter 없이 truffle-logback 모듈만 따로 사용 가능합니다. 이 경우 `logback-spring.xml` 등에 아래처럼 직접 설정하면 됩니다.

```xml
    <appender name="TRUFFLE" class="com.wafflestudio.truffle.sdk.logback.TruffleAppender">
        <options>
            <phase>dev</phase>
            <apiKey>test</apiKey>
            <minimumLevel>WARN</minimumLevel>
        </options>
    </appender>

    <root level="INFO">
        <appender-ref ref="TRUFFLE"/>
    </root>
```

물론, 이렇게 할 것 없이 truffle-spring-boot-starter 와 함께 logback 을 사용하는 프로젝트에서는 자동으로 TruffleAppender 가 설정됩니다. `truffle.logback.enabled: false`를 설정하면 제외됩니다.

```yml
truffle:
  client:
    phase: dev
    api-key: test
    minimum-level: WARN
```

2. apiKey, phase 같은 걸 제대로 설정 안 하면 서버 못 뜨고 터지는 건 문제를 빨리 알아채도록 의도했습니다.

- - -

**구현상 가장 고민이 된 부분들은 아래와 같은데 의견 주시면 좋아요.**

1. IHub 과 Hub, HubAdapter 의 존재가 애매한데, 지금으로서는 굳이.. 스럽게 복잡한 느낌이 있습니다. 사실 `Truffle`이라는 만능 singleton class 하나로 다 가능한데... Sentry 를 적당히 따라 해보려 한 느낌이라고 할 수 있고요. 추후의 확장성과 함께, `Truffle` singleton class 를 온갖 군데에서 직접 쓰는 것보다는 나은 패턴일 것이라는 기대로 이렇게 일단 만들었습니다.

2. truffle-spring-boot-starter 없이 logback 만 쓰는 경우엔, Appender 가 뜨는 시점이 Spring Bean 들 생성 속도보다 빠른데다가 truffle-logback 모듈엔 webflux 의존성이 없어서 `WebClient.Builder`를 커스텀하게 설정하게 해줄 수는 없는 상황입니다. 때문에 이 경우엔 그냥 `DefaultWebClientBuilder`가 사용되게 했습니다.
