### PR TITLE
AbortedException 로깅 제외

### DIFF
--- a/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
+++ b/truffle-spring-boot-starter/src/main/kotlin/reactive/TruffleWebExceptionHandler.kt
@@ -9,11 +9,12 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebExceptionHandler
 import reactor.core.publisher.Mono
+import reactor.netty.channel.AbortedException
 
 @Order(-2)
 class TruffleWebExceptionHandler(private val hub: IHub) : WebExceptionHandler {
     override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> {
-        if (ex !is ResponseStatusException) {
+        if (ex !is ResponseStatusException && ex !is AbortedException) {
             hub.captureEvent(
                 TruffleEvent(
                     level = TruffleLevel.FATAL,


### PR DESCRIPTION
해당 Exception이 client가 연결 끊을 시 언제든 발생할 수 있고 
Mono.error로 에러를 담을 때 한번 더 이 핸들러에 걸림