### PR TITLE
Preserve existing application environment properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@
       // ...
       dependencies {
         // ...
-        implementation 'com.wafflestudio.spring:spring-boot-starter-waffle:1.0.2'
+        implementation 'com.wafflestudio.spring:spring-boot-starter-waffle:1.0.3'
       }
       ```
 ## 기능 목록
 - [secret-manager](./spring-boot-starter-waffle-secret-manager)
     - secret-names 을 통해 AWS Secret Manager 에서 secret 을 가져오는 라이브러리
+    - 애플리케이션 환경에 이미 정의된 프로퍼티는 변경하지 않습니다.
     - 활성 property: `secret-names`
 - [truffle](./truffle)
     - 와플스튜디오 slack 채널에 로그를 전송하는 라이브러리

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
       // ...
       dependencies {
         // ...
-        implementation("com.wafflestudio.spring:spring-boot-starter-waffle:1.0.2")
+        implementation("com.wafflestudio.spring:spring-boot-starter-waffle:1.0.3")
       }
       ```
     - build.gradle

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@
 ## 기능 목록
 - [secret-manager](./spring-boot-starter-waffle-secret-manager)
     - secret-names 을 통해 AWS Secret Manager 에서 secret 을 가져오는 라이브러리
-    - 애플리케이션 환경에 이미 정의된 프로퍼티는 변경하지 않습니다.
     - 활성 property: `secret-names`
 - [truffle](./truffle)
     - 와플스튜디오 slack 채널에 로그를 전송하는 라이브러리

--- a/spring-boot-starter-waffle-secret-manager/README.md
+++ b/spring-boot-starter-waffle-secret-manager/README.md
@@ -22,13 +22,15 @@
       ```kotlin
       dependencies {
         //...
-        implementation("com.wafflestudio.spring:spring-boot-starter-waffle-secret-manager:1.0.2")
+        implementation("com.wafflestudio.spring:spring-boot-starter-waffle-secret-manager:1.0.3")
       }
       ```
     - build.gradle
       ```groovy
       dependencies {
         //...
-        implementation 'com.wafflestudio.spring:spring-boot-starter-waffle-secret-manager:1.0.2'
+        implementation 'com.wafflestudio.spring:spring-boot-starter-waffle-secret-manager:1.0.3'
       }
       ```
+#### Note
+- 애플리케이션 환경에 이미 정의된 프로퍼티는 변경하지 않습니다.

--- a/truffle/README.md
+++ b/truffle/README.md
@@ -20,14 +20,14 @@
       ```kotlin
       dependencies {
         //...
-        implementation("com.wafflestudio.spring.truffle:spring-boot-starter-truffle:1.0.2")
+        implementation("com.wafflestudio.spring.truffle:spring-boot-starter-truffle:1.0.3")
       }
       ```
     - build.gradle
       ```groovy
       dependencies {
         //...
-        implementation 'com.wafflestudio.spring.truffle:spring-boot-starter-truffle:1.0.2'
+        implementation 'com.wafflestudio.spring.truffle:spring-boot-starter-truffle:1.0.3'
       }
       ```
 

--- a/truffle/truffle-core/build.gradle.kts
+++ b/truffle/truffle-core/build.gradle.kts
@@ -4,5 +4,5 @@ dependencies {
     implementation("org.springframework:spring-web")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.4.2")
     implementation("org.slf4j:slf4j-api")
-    compileOnly("ch.qos.logback:logback-classic")
+    api("ch.qos.logback:logback-classic")
 }


### PR DESCRIPTION
- 애플리케이션 환경에 이미 정의된 프로퍼티는 AWS Secrets Manager에서 가져온 값으로 덮어쓰지 않도록 수정
- ex) 로컬에 띄운 redis에 연결하고 싶다면 애플리케이션에서 spring.data.redis.host=localhost 로 해두면 됨. AWS의 redis로 변경되지 않는다.